### PR TITLE
first impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "1 0 * * 0"
 
 env:
   CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on: [push, pull_request]
+
+env:
+  CI: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+      - name: Run tests
+        run: |
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ npm i fastify-raw-body
 
 ## Usage
 
-This plugin will add the `request.rawBody`. It will get the data thanks to the [`preParsing`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preparsing) hook.
+This plugin will add the `request.rawBody`.  
+It will get the data thanks to the [`preParsing`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preparsing) hook.
 
 ```js
 const Fastify = require('fastify')
 const app = Fastify()
 
-app.register(require('fastify-raw-body'), { 
+app.register(require('fastify-raw-body'), {
+  field: 'rawBody', // change the default request.rawBody property name
   global: false, // add the rawBody to every request. **Default true**
   encoding: 'utf8', // set it to false to set rawBody as a Buffer **Default utf8**
   runFirst: true // get the body before any preParsing hook change/uncompress it. **Default false**
@@ -33,6 +35,18 @@ app.post('/', {
   }
 })
 ```
+
+Notice: Setting `global: false` and then the route configuration `{ config: { rawBody: true } }` will
+save memory of your server since the `rawBody` is a copy of the `body` and it will double the memory usage.
+
+So use it only for the routes that you need to.
+
+### Raw body as Buffer
+
+It is important to know that setting `encoding: false` will add a [`addContentTypeParser`](https://www.fastify.io/docs/master/ContentTypeParser/) for `application/json`.
+This is needed since the default content type parser will set the encoding of the request stream as `{ parseAs: 'string' }`.
+
+If you don't have customized this component, it will be secure as the original one since [`secure-json-parse`](https://www.npmjs.com/package/secure-json-parse) is used under the hood.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ const Fastify = require('fastify')
 const app = Fastify()
 
 app.register(require('fastify-raw-body'), { 
-  global: false, // add the rawBody to every request. Default true
-  encoding: 'utf8', // set it to false to set rawBody as a Buffer
-  runFirst: true // get the body before any preParsing hook change/uncompress it. Default false
+  global: false, // add the rawBody to every request. **Default true**
+  encoding: 'utf8', // set it to false to set rawBody as a Buffer **Default utf8**
+  runFirst: true // get the body before any preParsing hook change/uncompress it. **Default false**
 })
 
 app.post('/', {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # fastify-raw-body
-Request raw body
+
+Adds the raw body to the Fastify request object.
+
+## Install
+
+```
+npm i fastify-raw-body
+```
+
+## Usage
+
+This plugin will add the `request.rawBody`. It will get the data thanks to the [`preParsing`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preparsing) hook.
+
+It will run as last `preParsing` hooks, this mean that if you change the payload, the `rawBody` will change too.
+
+```js
+const Fastify = require('fastify')
+const app = Fastify()
+
+app.register(require('fastify-raw-body'), { 
+  global: false, // add the rawBody to every request. Default true
+  encoding: 'utf8' // set it to false to set rawBody as a Buffer
+})
+
+app.post('/', {
+  config: {
+    // add the rawBody to this route. if false, rawBody will be disabled when global is true
+    rawBody: true
+  },
+  handler (req, reply) {
+    // req.rawBody the string raw body
+    reply.send(req.rawBody)
+  }
+})
+```
+
+## License
+
+Licensed under [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ npm i fastify-raw-body
 
 This plugin will add the `request.rawBody`. It will get the data thanks to the [`preParsing`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preparsing) hook.
 
-It will run as last `preParsing` hooks, this mean that if you change the payload, the `rawBody` will change too.
-
 ```js
 const Fastify = require('fastify')
 const app = Fastify()
 
 app.register(require('fastify-raw-body'), { 
   global: false, // add the rawBody to every request. Default true
-  encoding: 'utf8' // set it to false to set rawBody as a Buffer
+  encoding: 'utf8', // set it to false to set rawBody as a Buffer
+  runFirst: true // get the body before any preParsing change/uncompress it. Default false
 })
 
 app.post('/', {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastify-raw-body
 
-Adds the raw body to the Fastify request object.
+Adds the raw body to the Fastify **v3** request object.
 
 ## Install
 
@@ -19,7 +19,7 @@ const app = Fastify()
 app.register(require('fastify-raw-body'), { 
   global: false, // add the rawBody to every request. Default true
   encoding: 'utf8', // set it to false to set rawBody as a Buffer
-  runFirst: true // get the body before any preParsing change/uncompress it. Default false
+  runFirst: true // get the body before any preParsing hook change/uncompress it. Default false
 })
 
 app.post('/', {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # fastify-raw-body
 
+![ci](https://github.com/Eomm/fastify-raw-body/workflows/ci/badge.svg)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+
 Adds the raw body to the Fastify **v3** request object.
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "fastify-raw-body",
+  "version": "1.0.0",
+  "description": "Request raw body",
+  "main": "plugin.js",
+  "scripts": {
+    "test": "tap test/**.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Eomm/fastify-raw-body.git"
+  },
+  "keywords": [
+    "raw-body",
+    "body",
+    "request",
+    "fastify-raw-body"
+  ],
+  "author": "Manuel Spigolon <behemoth89@gmail.com> (https://github.com/Eomm)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Eomm/fastify-raw-body/issues"
+  },
+  "engines": {
+    "node": ">= 10"
+  },
+  "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
+  "devDependencies": {
+    "fastify": "^3.0.0-rc.4",
+    "standard": "^14.3.4",
+    "tap": "^14.10.7"
+  },
+  "dependencies": {
+    "fastify-plugin": "^2.0.0",
+    "raw-body": "^2.4.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^2.0.0",
-    "raw-body": "^2.4.1"
+    "raw-body": "^2.4.1",
+    "secure-json-parse": "^2.1.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -12,7 +12,8 @@ function rawBody (fastify, opts, next) {
     return
   }
 
-  const { encoding, global, runFirst } = Object.assign({
+  const { field, encoding, global, runFirst } = Object.assign({
+    field: 'rawBody',
     encoding: 'utf8',
     global: true,
     runFirst: false
@@ -64,7 +65,7 @@ function rawBody (fastify, opts, next) {
         return
       }
 
-      request.rawBody = string
+      request[field] = string
     })
 
     done(null, payload)

--- a/plugin.js
+++ b/plugin.js
@@ -51,7 +51,6 @@ function rawBody (fastify, opts, next) {
       // if (err) { return done(err) } // TODO
       request.rawBody = string
     })
-
     done(null, payload)
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,7 @@
 
 const fp = require('fastify-plugin')
 const getRawBody = require('raw-body')
+const secureJson = require('secure-json-parse')
 
 const kRawBodyHook = Symbol('fastify-raw-body:rawBodyHook')
 
@@ -16,6 +17,12 @@ function rawBody (fastify, opts, next) {
     global: true,
     runFirst: false
   }, opts)
+
+  if (encoding === false) {
+    fastify.addContentTypeParser('application/json',
+      { parseAs: 'buffer' },
+      almostDefaultJsonParser)
+  }
 
   fastify.addHook('onRoute', (routeOptions) => {
     const wantSkip = routeOptions.method === 'GET' || (routeOptions.config && routeOptions.config.rawBody === false)
@@ -44,14 +51,42 @@ function rawBody (fastify, opts, next) {
 
   function preparsingRawBody (request, reply, payload, done) {
     getRawBody(runFirst ? request.raw : payload, {
-      length: null, // avoid content lenght check
-      limit: fastify.initialConfig.bodyLimit,
+      length: null, // avoid content lenght check: fastify will do it
+      limit: fastify.initialConfig.bodyLimit, // limit to avoid memory leak or DoS
       encoding
-    }, function (_, string) {
-      // if (err) { return done(err) } // TODO
+    }, function (err, string) {
+      if (err) {
+        /**
+         * the error is managed by fastify server
+         * so the request object will not have any
+         * `body` parsed
+         */
+        return
+      }
+
       request.rawBody = string
     })
+
     done(null, payload)
+  }
+
+  function almostDefaultJsonParser (req, body, done) {
+    if (body.length === 0 || body == null) {
+      const err = new Error("Body cannot be empty when content-type is set to 'application/json'")
+      err.statusCode = 400
+      return done(err)
+    }
+
+    try {
+      var json = secureJson.parse(body.toString('utf8'), {
+        protoAction: fastify.initialConfig.onProtoPoisoning,
+        constructorAction: fastify.initialConfig.onConstructorPoisoning
+      })
+    } catch (err) {
+      err.statusCode = 400
+      return done(err)
+    }
+    done(null, json)
   }
 }
 

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+const getRawBody = require('raw-body')
+// const { PassThrough } = require('stream')
+
+const kRawBodyHook = Symbol('fastify-raw-body:rawBodyHook')
+
+function rawBody (fastify, opts, next) {
+  if (fastify[kRawBodyHook] === true) {
+    next(new Error('Cannot register fastify-raw-body twice'))
+    return
+  }
+
+  const { encoding, global } = Object.assign({
+    encoding: 'utf8',
+    global: true
+  }, opts)
+
+  fastify.addHook('onRoute', (routeOptions) => {
+    const wantSkip = routeOptions.method === 'GET' || (routeOptions.config && routeOptions.config.rawBody === false)
+
+    if ((global && !wantSkip) || (routeOptions.config && routeOptions.config.rawBody === true)) {
+      if (!routeOptions.preParsing) {
+        routeOptions.preParsing = [preparsingRawBody]
+      } else if (Array.isArray(routeOptions.preParsing)) {
+        routeOptions.preParsing.push(preparsingRawBody)
+      } else {
+        routeOptions.preParsing = [routeOptions.preParsing, preparsingRawBody]
+      }
+    }
+  })
+
+  fastify[kRawBodyHook] = true
+  next()
+
+  function preparsingRawBody (request, reply, payload, done) {
+    // const requestDataPassthrough = payload.pipe(new PassThrough())
+    getRawBody(payload, {
+      length: null, // avoid content lenght check
+      limit: fastify.initialConfig.bodyLimit,
+      encoding: encoding
+    }, function (_, string) {
+      // if (err) { return done(err) } // TODO
+      request.rawBody = string
+    })
+
+    // if (payload.receivedEncodedLength) {
+    //   requestDataPassthrough.receivedEncodedLength = payload.receivedEncodedLength
+    // }
+    done(null, payload)
+  }
+}
+
+module.exports = fp(rawBody, {
+  fastify: '^3.0.0',
+  name: 'fastify-raw-body'
+})

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -44,16 +44,6 @@ t.test('raw body flow check', t => {
     reply.send(req.rawBody)
   })
 
-  app.post('/', {
-    config: {
-      rawBody: true
-    },
-    handler (req, reply) {
-      t.ok(req.rawBody)
-      reply.send(req.rawBody)
-    }
-  })
-
   app.inject({
     method: 'POST',
     url: '/',

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -321,19 +321,19 @@ t.test('raw body route array', t => {
   })
 })
 
-t.test('raw body buffer', { skip: 'not working' }, t => {
+t.test('raw body buffer', t => {
   t.plan(5)
   const app = Fastify()
 
   const payload = { hello: 'world' }
 
-  app.register(rawBody, { encoding: 'buffer' })
+  app.register(rawBody, { encoding: false })
 
   app.post('/', (req, reply) => {
     t.deepEquals(req.body, { hello: 'world' })
     console.log({ x: req.rawBody })
 
-    // t.type(req.rawBody, Buffer)
+    t.type(req.rawBody, Buffer)
     reply.send(req.rawBody)
   })
 
@@ -345,5 +345,27 @@ t.test('raw body buffer', { skip: 'not working' }, t => {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.equals(res.payload, JSON.stringify(payload))
+  })
+})
+
+t.test('body limit', t => {
+  t.plan(2)
+  const app = Fastify({ bodyLimit: 5 })
+
+  const payload = { hello: 'world' }
+
+  app.register(rawBody, { encoding: false })
+
+  app.post('/', (req, reply) => {
+    t.fail('body is too large')
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 413)
   })
 })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,271 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const { Readable } = require('stream')
+const rawBody = require('../plugin')
+
+t.test('raw body flow check', t => {
+  t.plan(9)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+  const shouldBe = JSON.stringify(payload)
+
+  app.register(rawBody, { global: false })
+
+  app.addHook('onRequest', (request, reply, done) => {
+    t.notOk(request.rawBody)
+    done()
+  })
+
+  app.addHook('preParsing', (request, reply, payload, done) => {
+    t.notOk(request.rawBody)
+    done(null, payload)
+  })
+
+  app.addHook('preValidation', (request, reply, done) => {
+    t.equal(request.rawBody, shouldBe)
+    done()
+  })
+
+  app.addHook('preHandler', (request, reply, done) => {
+    t.equal(request.rawBody, shouldBe)
+    done()
+  })
+
+  app.addHook('onSend', (request, reply, payload, done) => {
+    t.equal(request.rawBody, shouldBe)
+    done(null, payload)
+  })
+
+  app.post('/', { config: { rawBody: true } }, (req, reply) => {
+    t.ok(req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.post('/', {
+    config: {
+      rawBody: true
+    },
+    handler (req, reply) {
+      t.ok(req.rawBody)
+      reply.send(req.rawBody)
+    }
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, shouldBe)
+  })
+})
+
+t.test('no register raw body twice', t => {
+  t.plan(2)
+  const app = Fastify()
+
+  app.register(rawBody)
+  app.register(rawBody)
+
+  app.ready(err => {
+    t.ok(err)
+    t.like(err.message, /twice/)
+  })
+})
+
+t.test('register in plugins', t => {
+  t.plan(1)
+  const app = Fastify()
+
+  app.register((i, o, next) => {
+    i.register(rawBody)
+    next()
+  })
+  app.register((i, o, next) => {
+    i.register(rawBody)
+    next()
+  })
+
+  app.ready(err => { t.error(err) })
+})
+
+t.test('raw body not in GET', t => {
+  t.plan(8)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+  const shouldBe = JSON.stringify(payload)
+
+  app.register(rawBody)
+
+  app.get('/', (req, reply) => {
+    t.notOk(req.rawBody)
+    reply.send(`raw=${req.rawBody}`)
+  })
+
+  app.post('/', (req, reply) => {
+    t.ok(req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.inject({
+    method: 'GET',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, 'raw=undefined')
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, shouldBe)
+  })
+})
+
+t.test('global skip', t => {
+  t.plan(8)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+  const shouldBe = JSON.stringify(payload)
+
+  app.register(rawBody)
+
+  app.post('/skip', { config: { rawBody: false } }, (req, reply) => {
+    t.notOk(req.rawBody)
+    reply.send(`raw=${req.rawBody}`)
+  })
+
+  app.post('/', (req, reply) => {
+    t.ok(req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/skip',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, 'raw=undefined')
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, shouldBe)
+  })
+})
+
+t.test('raw body is the last body stream value', t => {
+  t.plan(14)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+
+  let order = 0
+  app.addHook('preParsing', function (req, reply, payload, done) {
+    t.equals(order++, 0)
+    const change = new Readable()
+    change.receivedEncodedLength = parseInt(req.headers['content-length'], 10)
+    change.push('{"hello":"another world"}')
+    change.push(null)
+    done(null, change)
+  })
+
+  app.register(rawBody)
+
+  app.post('/', (req, reply) => {
+    t.deepEquals(req.body, { hello: 'another world' })
+    t.equals(JSON.stringify(req.body), req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.post('/preparsing', {
+    preParsing: function (req, reply, payload, done) {
+      t.equals(order++, 1)
+      t.notOk(req.rawBody)
+      const change = new Readable()
+      change.receivedEncodedLength = parseInt(req.headers['content-length'], 10)
+      change.push('{"hello":"last world"}')
+      change.push(null)
+      done(null, change)
+    }
+  }, (req, reply) => {
+    t.deepEquals(req.body, { hello: 'last world' })
+    t.equals(JSON.stringify(req.body), req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, JSON.stringify({ hello: 'another world' }))
+
+    order = 0 // reset the global order
+    app.inject({
+      method: 'POST',
+      url: '/preparsing',
+      payload
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      t.equals(res.payload, JSON.stringify({ hello: 'last world' }))
+    })
+  })
+})
+
+t.test('raw body route array', t => {
+  t.plan(6)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+
+  app.register(rawBody)
+
+  app.post('/preparsing', {
+    preParsing: [function (req, reply, payload, done) {
+      t.notOk(req.rawBody)
+      const change = new Readable()
+      change.receivedEncodedLength = parseInt(req.headers['content-length'], 10)
+      change.push('{"hello":"last world"}')
+      change.push(null)
+      done(null, change)
+    }]
+  }, (req, reply) => {
+    t.deepEquals(req.body, { hello: 'last world' })
+    t.equals(JSON.stringify(req.body), req.rawBody)
+    reply.send(req.rawBody)
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/preparsing',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, JSON.stringify({ hello: 'last world' }))
+  })
+})

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -357,6 +357,31 @@ t.test('preparsing run first', t => {
   })
 })
 
+t.test('raw body change default name', t => {
+  t.plan(5)
+  const app = Fastify()
+
+  const payload = { hello: 'world' }
+
+  app.register(rawBody, { field: 'rawRawRaw', encoding: false })
+
+  app.post('/', (req, reply) => {
+    t.deepEquals(req.body, { hello: 'world' })
+    t.type(req.rawRawRaw, Buffer)
+    reply.send(req.rawRawRaw)
+  })
+
+  app.inject({
+    method: 'POST',
+    url: '/',
+    payload
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equals(res.payload, JSON.stringify(payload))
+  })
+})
+
 t.test('raw body buffer', t => {
   t.plan(5)
   const app = Fastify()


### PR DESCRIPTION
Doubt:

right now if a client send `hello` and the user set an instance hook:

`app.addHook('preParsing', function (req, reply, payload, done) {...` that changes `hello` to `goodbye`, the `request.rawBody` will be equals to `goodbye`.

I think that there is not an easy way to get `hello` since the application hook is not listed in the `onRoute` hook.
I can manage the order of route's hook only.

Is this "not a problem"? Since the `preParsing` could be used to run decompression.

---

Edit: found how to get the body before any `preParsing` change it: add `runFirst` option


TODO
- [x] manage `getRawBodyError`
- [x] test request errors
- [x] test buffer


Closes https://github.com/fastify/fastify/issues/707