### PR TITLE
fix release gap to support fastify v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,22 @@
 ![ci](https://github.com/Eomm/fastify-raw-body/workflows/ci/badge.svg)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 
-Adds the raw body to the Fastify **v3** request object.
+Adds the raw body to the Fastify request object.
 
 ## Install
 
+### Fastify v3
+
 ```
 npm i fastify-raw-body
+```
+
+### Fastify v2
+
+The version `2.x` of this module support Fastify v2 and Node.js>=6
+
+```
+npm i fastify-raw-body@2.0.0
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-raw-body",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Request raw body",
   "main": "plugin.js",
   "scripts": {


### PR DESCRIPTION
Recap:

- v1.0.0 support fastify v3 and node>=10
- v2.0.0 adds support for fastify v2 and node >= 6. This is not tagged as `@latest` on npm so it must be installed manually by the user
- v3.0.0 will be released to fix the case that v1 is latest and v2 is not. This version will be strict equals to the v1.0.0