### PR TITLE
Add typescript types for 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
   "types": "types/plugin.d.ts",
   "devDependencies": {
+    "@types/node": "^14.11.2",
+    "fastify": "^2.15.1",
     "standard": "^14.3.4",
     "tap": "^12.6.1",
-    "fastify": "^2.15.1",
     "typescript": "^4.0.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "node": ">= 6"
   },
   "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
+  "types": "types/plugin.d.ts",
   "devDependencies": {
-    "fastify": "^2.15.1",
     "standard": "^14.3.4",
-    "tap": "^12.6.1"
+    "tap": "^12.6.1",
+    "fastify": "^2.15.1",
+    "typescript": "^4.0.3"
   },
   "dependencies": {
     "fastify-plugin": "^1.0.0",

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,4 +1,4 @@
-import * as fastify from "fastify"
+import fastify from "fastify"
 import { Server, IncomingMessage, ServerResponse } from "http"
 
 declare const fp: fastify.Plugin<Server, IncomingMessage, ServerResponse, any>

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,0 +1,5 @@
+import * as fastify from "fastify"
+import { Server, IncomingMessage, ServerResponse } from "http"
+
+declare const fp: fastify.Plugin<Server, IncomingMessage, ServerResponse, any>
+export default fp

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": [ "es2015" ],
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": [
+     "/types/*.d.ts"
+  ]
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -8,6 +8,6 @@
     "strict": true
   },
   "include": [
-     "/types/*.d.ts"
+     "*.d.ts"
   ]
 }


### PR DESCRIPTION
I added the necessary type definitions to import and register the plugin in typescript, the dynamic decoration of the FastifyRequest type is problematic though. I have no idea if that is even possible to type in a `.d.ts` file. That means that the typescript parser throws an error when trying to access FastifyRequest.rawBody. 

A possible workaround for this is to define the type in the application using this plugin.