### PR TITLE
Add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Request raw body",
   "main": "plugin.js",
+  "types": "plugin.d.ts",
   "scripts": {
     "test": "standard && tap test/**.test.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "scripts": {
-    "test": "standard && tap test/**.test.js"
+    "test": "standard && tap test/**.test.js",
+    "typescript": "tsd"
   },
   "repository": {
     "type": "git",
@@ -27,13 +28,18 @@
   },
   "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
   "devDependencies": {
+    "@types/node": "^14.14.17",
     "fastify": "^3.0.0-rc.4",
     "standard": "^14.3.4",
-    "tap": "^14.10.7"
+    "tap": "^14.10.7",
+    "tsd": "^0.14.0"
   },
   "dependencies": {
     "fastify-plugin": "^2.0.0",
     "raw-body": "^2.4.1",
     "secure-json-parse": "^2.1.0"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "scripts": {
-    "test": "standard && tap test/**.test.js",
-    "typescript": "tsd"
+    "test": "standard && tap test/**.test.js && tsd"
   },
   "repository": {
     "type": "git",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -11,7 +11,7 @@ declare namespace FastifyRawBody {
 
 declare module 'fastify' {
   interface FastifyRequest {
-    rawBody: string | Buffer
+    rawBody?: string | Buffer
   }
 }
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -2,10 +2,10 @@ import { FastifyPluginCallback } from 'fastify'
 
 declare namespace FastifyRawBody {
   interface Options {
-    field: string
-    global: boolean
-    encoding: string | null | false
-    runFirst: boolean
+    field?: string
+    global?: boolean
+    encoding?: string | null | false
+    runFirst?: boolean
   }
 }
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,19 +1,17 @@
 import { FastifyPluginCallback } from 'fastify'
 
-declare namespace FastifyRawBody {
-  interface Options {
-    field?: string
-    global?: boolean
-    encoding?: string | null | false
-    runFirst?: boolean
-  }
-}
-
 declare module 'fastify' {
   interface FastifyRequest {
     rawBody?: string | Buffer
   }
 }
 
-declare const fastifyRawBody: FastifyPluginCallback<FastifyRawBody.Options>
+export interface RawBodyPluginOptions {
+  field?: string
+  global?: boolean
+  encoding?: string | null | false
+  runFirst?: boolean
+}
+
+declare const fastifyRawBody: FastifyPluginCallback<RawBodyPluginOptions>
 export default fastifyRawBody

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,0 +1,19 @@
+import { FastifyPluginCallback } from 'fastify'
+
+declare namespace FastifyRawBody {
+  interface Options {
+    field: string
+    global: boolean
+    encoding: string | null | false
+    runFirst: boolean
+  }
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    rawBody: string | Buffer
+  }
+}
+
+declare const fastifyRawBody: FastifyPluginCallback<FastifyRawBody.Options>
+export default fastifyRawBody

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": true
+  },
+  "files": ["./types.test.ts"]
+}

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,0 +1,17 @@
+import fastifyFactory from 'fastify'
+import rawBodyPlugin, { RawBodyPluginOptions } from '../../plugin'
+
+const optionsNone: RawBodyPluginOptions = {}
+const options1: RawBodyPluginOptions = { global: false }
+const options2: RawBodyPluginOptions = { field: 'bodyRaw' }
+const options3: RawBodyPluginOptions = { encoding: false }
+const options4: RawBodyPluginOptions = { runFirst: false }
+const options5: RawBodyPluginOptions = { field: 'rawBuffer', encoding: false }
+
+const fastify = fastifyFactory()
+fastify.register(rawBodyPlugin, optionsNone)
+fastify.register(rawBodyPlugin, options1)
+fastify.register(rawBodyPlugin, options2)
+fastify.register(rawBodyPlugin, options3)
+fastify.register(rawBodyPlugin, options4)
+fastify.register(rawBodyPlugin, options5)


### PR DESCRIPTION
The typings are super simple but just what's needed: types the options the plugin takes and adds the `rawBody` property to the `FastifyRequest` interface (it doesn't take into account the `field` configuration flag, but there's no way of doing this unfortunately; people who want to use a custom field will have to type it on their own as well).

Closes #6