### PR TITLE
feat: support routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ app.register(require('fastify-raw-body'), {
   field: 'rawBody', // change the default request.rawBody property name
   global: false, // add the rawBody to every request. **Default true**
   encoding: 'utf8', // set it to false to set rawBody as a Buffer **Default utf8**
-  runFirst: true // get the body before any preParsing hook change/uncompress it. **Default false**
+  runFirst: true, // get the body before any preParsing hook change/uncompress it. **Default false**
+  routes: [] // array of routes, **global** will be ignored
 })
 
 app.post('/', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-raw-body",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Request raw body",
   "main": "plugin.js",
   "types": "plugin.d.ts",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -11,6 +11,7 @@ export interface RawBodyPluginOptions {
   global?: boolean
   encoding?: string | null | false
   runFirst?: boolean
+  routes?: string[]
 }
 
 declare const fastifyRawBody: FastifyPluginCallback<RawBodyPluginOptions>

--- a/plugin.js
+++ b/plugin.js
@@ -12,11 +12,12 @@ function rawBody (fastify, opts, next) {
     return
   }
 
-  const { field, encoding, global, runFirst } = Object.assign({
+  const { field, encoding, global, runFirst, routes } = Object.assign({
     field: 'rawBody',
     encoding: 'utf8',
     global: true,
-    runFirst: false
+    runFirst: false,
+    routes: []
   }, opts)
 
   if (encoding === false) {
@@ -28,7 +29,11 @@ function rawBody (fastify, opts, next) {
   fastify.addHook('onRoute', (routeOptions) => {
     const wantSkip = routeOptions.method === 'GET' || (routeOptions.config && routeOptions.config.rawBody === false)
 
-    if ((global && !wantSkip) || (routeOptions.config && routeOptions.config.rawBody === true)) {
+    if (
+      (global && !wantSkip && !routes.length) ||
+      (routeOptions.config && routeOptions.config.rawBody === true) ||
+      routes.includes(routeOptions.path)
+    ) {
       if (!routeOptions.preParsing) {
         routeOptions.preParsing = [preparsingRawBody]
       } else if (Array.isArray(routeOptions.preParsing)) {


### PR DESCRIPTION
Hi, we could have an option to declare routes during plugin registration. That would help when using Fastify with NestJS where there is no option to set config on route like:

```
fastify.get('/en', { config: { rawBody: true } }, handler)
```

example usage: 

```
  app.register(rawBody2, {
    field: 'rawBody',
    global: false,
    encoding: false,
    runFirst: true,
    routes: ['/api/user/v1', 'api/contact/v1'],
  });
```