### PR TITLE
Fix FastifyDeprecation warning of request.context usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "fastify": "^4.0.0-rc.4",
+    "fastify": "^4.10.0",
     "standard": "^17.0.0",
     "tap": "^16.2.0",
     "tsd": "^0.24.1"

--- a/plugin.js
+++ b/plugin.js
@@ -56,7 +56,7 @@ function rawBody (fastify, opts, next) {
   next()
 
   function preparsingRawBody (request, reply, payload, done) {
-    const applyLimit = request.routeConfig.bodyLimit ?? fastify.initialConfig.bodyLimit
+    const applyLimit = request.routeOptions.bodyLimit ?? fastify.initialConfig.bodyLimit
 
     getRawBody(runFirst ? request.raw : payload, {
       length: null, // avoid content lenght check: fastify will do it

--- a/plugin.js
+++ b/plugin.js
@@ -56,7 +56,7 @@ function rawBody (fastify, opts, next) {
   next()
 
   function preparsingRawBody (request, reply, payload, done) {
-    const applyLimit = request.context._parserOptions.limit ?? fastify.initialConfig.bodyLimit
+    const applyLimit = request.routeConfig.bodyLimit ?? fastify.initialConfig.bodyLimit
 
     getRawBody(runFirst ? request.raw : payload, {
       length: null, // avoid content lenght check: fastify will do it


### PR DESCRIPTION
Since version 4.1.1 following error appeared in my projects:
`[FSTDEP012] FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in fastify@5`

It's connected to route body limit PR. Request#context field is deprecated. Direct usage of routeConfig works better.
