### PR TITLE
Add missing route config type

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/Eomm/fastify-raw-body#readme",
   "devDependencies": {
     "@types/node": "^20.1.0",
-    "fastify": "^4.10.0",
+    "fastify": "^4.19.0",
     "standard": "^17.0.0",
     "tap": "^16.2.0",
     "tsd": "^0.28.0"

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -4,6 +4,10 @@ declare module 'fastify' {
   interface FastifyRequest {
     rawBody?: string | Buffer
   }
+
+  interface FastifyContextConfig {
+    rawBody?: boolean
+  }
 }
 
 type FastifyRawBody = FastifyPluginCallback<fastifyRawBody.RawBodyPluginOptions> 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -15,3 +15,5 @@ fastify.register(rawBodyPlugin, options2)
 fastify.register(rawBodyPlugin, options3)
 fastify.register(rawBodyPlugin, options4)
 fastify.register(rawBodyPlugin, options5)
+
+fastify.get('/', { config: { rawBody: true } }, () => { return "rawBody enabled" })

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,3 +1,5 @@
+import { expectType } from 'tsd'
+
 import fastifyFactory from 'fastify'
 import rawBodyPlugin, { RawBodyPluginOptions } from '../../plugin'
 
@@ -16,4 +18,7 @@ fastify.register(rawBodyPlugin, options3)
 fastify.register(rawBodyPlugin, options4)
 fastify.register(rawBodyPlugin, options5)
 
-fastify.get('/', { config: { rawBody: true } }, () => { return "rawBody enabled" })
+fastify.get('/', { config: { rawBody: true } }, (request, reply) => {
+  expectType<boolean | undefined>(request.routeConfig.rawBody)
+  return "rawBody enabled"
+})


### PR DESCRIPTION
as of fastify 4.19.0 route configs have to be typed explicitly, without this change with fastify 4.19.0 and above a route like

```typescript
f.get("/foo", { config: { rawBody: true } }, () => {})
```

produces the following error:
```
Type '{ auth: "public"; rawBody: true; }' is not assignable to type 'Omit<FastifyContextConfig & FastifyRouteConfig, "url" | "method">'.
  Object literal may only specify known properties, and 'rawBody' does not exist in type 'Omit<FastifyContextConfig & FastifyRouteConfig, "url" | "method">'.
```


See https://github.com/fastify/fastify-rate-limit/pull/306 for a similar fix in an official fastify plugin.